### PR TITLE
Add label selector for namespace and decrease timeout to 10 seconds

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -128,7 +128,7 @@ func main() {
 	}
 
 	// Start up the wehook server
-	if err := setupWebhooks(mgr); err != nil {
+	if err := setupWebhooks(mgr, namespace); err != nil {
 		klog.Error(err, "Error setting up webhook server")
 	}
 
@@ -210,7 +210,7 @@ func serveCRMetrics(cfg *rest.Config) error {
 	return nil
 }
 
-func setupWebhooks(mgr manager.Manager) error {
+func setupWebhooks(mgr manager.Manager, namespace string) error {
 
 	klog.Info("Creating common service webhook configuration")
 	webhooks.Config.AddWebhook(webhooks.CSWebhook{
@@ -233,7 +233,7 @@ func setupWebhooks(mgr manager.Manager) error {
 	})
 
 	klog.Info("setting up webhook server")
-	if err := webhooks.Config.SetupServer(mgr); err != nil {
+	if err := webhooks.Config.SetupServer(mgr, namespace); err != nil {
 		return err
 	}
 

--- a/deploy/clusterrole.yaml
+++ b/deploy/clusterrole.yaml
@@ -12,6 +12,16 @@ rules:
       - get
       - create
   - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - list
+      - get
+      - create
+      - update
+      - watch
+  - apiGroups:
       - operator.ibm.com
     resources:
       - '*'

--- a/version/version.go
+++ b/version/version.go
@@ -18,5 +18,5 @@ package version
 
 var (
 	// Version of the operator
-	Version = "1.1.1"
+	Version = "1.2.0"
 )


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

This PR is for fixing `admission plugin "MutatingAdmissionWebhook" failed to complete mutation in 13s` issue on the openshift.

Add namespace selector to watch CR's namespace only.

A namespace selector is added into the mutation webhook configuration. 
**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
